### PR TITLE
HW 7

### DIFF
--- a/kubernetes-operators/deploy/cr.yml
+++ b/kubernetes-operators/deploy/cr.yml
@@ -1,0 +1,9 @@
+apiVersion: otus.homework/v1
+kind: MySQL
+metadata:
+  name: mysql-instance
+spec:
+  image: mysql:5.7
+  database: otus-database
+  password: otuspassword  # Так делать не нужно, следует использовать secret
+  storage_size: 1Gi

--- a/kubernetes-operators/deploy/crd.yml
+++ b/kubernetes-operators/deploy/crd.yml
@@ -1,0 +1,41 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: mysqls.otus.homework # имя CRD должно иметь формат plural.group
+spec:
+  scope: Namespaced     # Данный CRD будер работать в рамках namespace
+  group: otus.homework  # Группа, отражается в поле apiVersion CR
+  versions:             # Список версий
+    - name: v1
+      served: true      # Будет ли обслуживаться API-сервером данная версия
+      storage: true     # Фиксирует  версию описания, которая будет сохраняться в etcd
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+              properties:
+                name:
+                  type: string
+            spec:
+              type: object
+              properties:
+                image: 
+                  type: string
+                database:
+                  type: string
+                password:
+                  type: string
+                storage_size:
+                  type: string
+  names:                # различные форматы имени объекта CR
+    kind: MySQL         # kind CR
+    plural: mysqls      
+    singular: mysql
+    shortNames:
+      - ms

--- a/kubernetes-operators/deploy/data.sh
+++ b/kubernetes-operators/deploy/data.sh
@@ -1,0 +1,7 @@
+export MYSQLPOD=$(kubectl get pods -l app=mysql-instance -o jsonpath="{.items[*].metadata.name}")
+
+#kubectl exec -it $MYSQLPOD -- mysql -u root -potuspassword -e "CREATE TABLE test (id smallint unsigned not null auto_increment, name varchar(20) not null, constraint pk_example primary key (id) );" otus-database
+#kubectl exec -it $MYSQLPOD -- mysql -potuspassword -e "INSERT INTO test ( id, name) VALUES ( null, 'some data' );" otus-database
+#kubectl exec -it $MYSQLPOD -- mysql -potuspassword -e "INSERT INTO test ( id, name ) VALUES ( null, 'some data-2' );" otus-database
+
+kubectl exec -it $MYSQLPOD -- mysql -potuspassword -e "select * from test;" otus-database

--- a/kubernetes-operators/deploy/deploy-operator.yml
+++ b/kubernetes-operators/deploy/deploy-operator.yml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mysql-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: mysql-operator
+  template:
+    metadata:
+      labels:
+        name: mysql-operator
+    spec:
+      serviceAccountName: mysql-operator
+      containers:
+        - name: operator
+          image: "zhenkins/mysql-operator:v0.1"
+          imagePullPolicy: "Always"

--- a/kubernetes-operators/deploy/role-binding.yml
+++ b/kubernetes-operators/deploy/role-binding.yml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: workshop-operator
+subjects:
+- kind: ServiceAccount
+  name: mysql-operator
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: mysql-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/kubernetes-operators/deploy/role.yml
+++ b/kubernetes-operators/deploy/role.yml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: mysql-operator
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'

--- a/kubernetes-operators/deploy/service-account.yml
+++ b/kubernetes-operators/deploy/service-account.yml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mysql-operator


### PR DESCRIPTION
# Выполнено ДЗ № 7

 - [x ] Основное ДЗ
 - [ ] Задание со *

## В процессе сделано:
CRD

Создано Custom Resource Definition. Пример из методички устарел, версия api теперь v1, в манифест также необходимо добавить раздел schema.

Применены все манифесты, в базу добавлены данные.

kubectl exec -it $MYSQLPOD -- mysql -potuspassword -e "select * from test;" otus-database
mysql: [Warning] Using a password on the command line interface can be insecure.

 +----+-------------+
 | id | name        |
 +----+-------------+
 |  1 | some data   |
 |  2 | some data-2 |
 +----+-------------+

Далее необходимо удалить базу, но команда kubectl delete mysqls.otus.homework mysql-instance запускает джоб бекапа, который зависает.
Соответственно восстановления тоже не происходит.
Скорее всего причина в устаревшем образе zhenkins/mysql-operator:v0.1




## Как запустить проект:
Применить все манифесты

## Как проверить работоспособность:

## PR checklist:
 - [x] Выставлен label с темой домашнего задания
